### PR TITLE
Use dynosaur-core as module name

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -3,7 +3,7 @@
 Add to your `build.sbt`
 
 ```scala
-libraryDependencies += "org.systemfw" %% "dynosaur" % "@version@"
+libraryDependencies += "org.systemfw" %% "dynosaur-core" % "@version@"
 ```
 
 `Dynosaur` is published for the following versions of Scala:


### PR DESCRIPTION
The installing doc refers to `dynosaur` module, but apparently, it is call `dynosaur-core` instead