### PR TITLE
Override error get message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ target/
 .history/
 .bsp/
 .DS_Store
-
+.vscode/
+.bloop/
+.metals/
+metals.sbt
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,11 @@
 version = "3.5.8"
 align.preset = none
-runner.dialect = scala212
+runner.dialect = scala213
+fileOverride {
+  "glob:**/src/*/scala-3" {
+    runner.dialect = scala3
+  }
+  "glob:**/src/*/scala-2.12" {
+    runner.dialect = scala212
+  }
+}

--- a/modules/core/src/main/scala/Schema.scala
+++ b/modules/core/src/main/scala/Schema.scala
@@ -103,13 +103,10 @@ object Schema {
 
   trait DynosaurError extends Exception with Product with Serializable {
     def message: String
+    override def getMessage = message
   }
-  case class ReadError(message: String) extends DynosaurError {
-    override def toString(): String = s"ReadError($message)"
-  }
-  case class WriteError(message: String) extends DynosaurError {
-    override def toString(): String = s"WriteError($message)"
-  }
+  case class ReadError(message: String) extends DynosaurError
+  case class WriteError(message: String) extends DynosaurError
 
   def apply[A](implicit schema: Schema[A]): Schema[A] = schema
 

--- a/modules/core/src/test/scala/ErrorsSuite.scala
+++ b/modules/core/src/test/scala/ErrorsSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Fabio Labella
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynosaur
+
+import org.scalacheck.Prop
+import dynosaur.Arbitraries._
+
+class ErrorSuite extends munit.ScalaCheckSuite {
+
+  test("ReadError toString must contain the message") {
+    Prop.forAllNoShrink { message: String =>
+      val result = Schema.ReadError(message).toString
+      assert(
+        result.contains(message),
+        s"The toString result: '${result}' does not contain '${message}'"
+      )
+    }
+  }
+
+  test("WriteError toString must contain the message") {
+    Prop.forAllNoShrink { message: String =>
+      val result = Schema.WriteError(message).toString
+      assert(
+        result.contains(message),
+        s"The toString result: '${result}' does not contain '${message}'"
+      )
+    }
+  }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.7.2


### PR DESCRIPTION
The `ReadError` and `WriteError` where not printed correctly from the JVM stack trace, because the `getMessage` was returning `null`.

This PR removed the `toString` override from those errors and instead override the `getMessage` from the `DynosaurError` trait.

This also adds some bit and pieces:
- Sets different scalafmt dialect by scala version
- Bumps up sbt version
- Ignore vscode+metals files