### PR TITLE
Upgrade awssdk to v2.21.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "dynamodb" % "2.14.15"
+      "software.amazon.awssdk" % "dynamodb" % "2.21.5"
     )
   )
 


### PR DESCRIPTION
Upgrade AWS SDK to latest version i.e. v2.21.5. The library seems to have gotten downgraded to 2.14.15 that was released 2020-09-10.